### PR TITLE
Fixes crackTimeDisplay returns "instant" for large passwords

### DIFF
--- a/Zxcvbn/Zxcvbn/DBScorer.m
+++ b/Zxcvbn/Zxcvbn/DBScorer.m
@@ -360,7 +360,7 @@ static int kNumDays = 31;
     return digits + upper + lower + symbols;
 }
 
-- (NSString *)displayTime:(int)seconds
+- (NSString *)displayTime:(float)seconds
 {
     int minute = 60;
     int hour = minute * 60;


### PR DESCRIPTION
When seconds (crackTime) is larger than 31Bit it becomes negative resulting in "instant" as crackTimeDisplay. 

Fixes: #3
