### PR TITLE
Use bundleForClass instead of mainBundle

### DIFF
--- a/Zxcvbn/Zxcvbn/DBMatcher.m
+++ b/Zxcvbn/Zxcvbn/DBMatcher.m
@@ -606,7 +606,7 @@ typedef NSArray* (^MatcherBlock)(NSString *password);
 {
     NSMutableArray *dictionaryMatchers = [[NSMutableArray alloc] init];
     
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"frequency_lists" ofType:@"json"];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"frequency_lists" ofType:@"json"];
     NSData *data = [NSData dataWithContentsOfFile:filePath];
     
     NSError *error;
@@ -629,7 +629,7 @@ typedef NSArray* (^MatcherBlock)(NSString *password);
 
 - (NSDictionary *)loadAdjacencyGraphs
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"adjacency_graphs" ofType:@"json"];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"adjacency_graphs" ofType:@"json"];
     NSData *data = [NSData dataWithContentsOfFile:filePath];
     
     NSError *error;


### PR DESCRIPTION
Getting the resource paths for adjacency_graphs.json and frequency_lists.json returns `nil` when zxcvbn-ios is in a framework. Replacing `[NSBundle mainBundle]` with `[NSBundle bundleForClass:[self class]]` solves this problem and works for zxcvbn-ios when is in the main application or in a framework.

This problem can easily be seen by adding zxcvbn-ios to a project via CocoaPods with the `use_frameworks!` option in the Podfile.