### PR TITLE
Add missing [super awakeFromNib] call

### DIFF
--- a/Zxcvbn/DBPasswordStrengthMeterView.m
+++ b/Zxcvbn/DBPasswordStrengthMeterView.m
@@ -43,6 +43,8 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
+
     [self sharedInit];
 }
 


### PR DESCRIPTION
I was getting the following warning `DBPasswordStrengthMeterView.m:47:1: warning: method possibly missing a [super awakeFromNib] call [-Wobjc-missing-super-calls]`, thus added the missing call to `[super awakeFromNib]`.